### PR TITLE
feat: add wrong Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ COPY . /app
 
 WORKDIR /app
 
+RUN this_command_does_not_exist
+
 CMD ["pytho", "hello1.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY . /app
 
 WORKDIR /app
 
-CMD ["python3", "hello1.py"]
+CMD ["pytho", "hello1.py"]


### PR DESCRIPTION
## Purpose of this PR
This pull request intentionally introduces a build-time error in the Dockerfile to verify that our CI pipeline correctly detects and fails when an error occurs during the Docker build process.

## What was changed
Added a non-existent command (this_command_does_not_exist) to the Dockerfile to simulate a build failure.

## Expected Result
The CI workflow should fail during the Docker build step, confirming that our failure detection is working as intended.